### PR TITLE
Create mock experimentation Dash interface

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on:
+  push:
+    paths:
+      - 'Experimentation/site/**'
+      - '.github/workflows/tests.yml'
+  pull_request:
+    paths:
+      - 'Experimentation/site/**'
+      - '.github/workflows/tests.yml'
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install causalpy dash dash-bootstrap-components pandas numpy plotly pytest
+
+      - name: Run pytest
+        run: pytest Experimentation/site/tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# Python bytecode caches
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Test and tooling caches
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Notebook checkpoints
+.ipynb_checkpoints/
+
+# Virtual environments
+.venv/
+venv/
+env/
+ENV/
+env.bak/
+venv.bak/
+
+# Package build artifacts
+build/
+dist/
+*.egg-info/
+
+# macOS filesystem noise
+.DS_Store
+
+# Dash experimentation generated assets
+Experimentation/site/data/
+

--- a/Experimentation/__init__.py
+++ b/Experimentation/__init__.py
@@ -1,0 +1,3 @@
+"""Marketing science experimentation package."""
+
+

--- a/Experimentation/site/README.md
+++ b/Experimentation/site/README.md
@@ -1,0 +1,40 @@
+# Experimentation Studio (Mock Interface)
+
+This project provides a mock experimentation workspace built with [Dash](https://dash.plotly.com/) and Plotly. It is designed to showcase the proposed workflow for configuring marketing science experiments before connecting to real CausalPy runs.
+
+## Features
+
+- **Prompt-driven experiments**: Capture free-form experiment requests and structured metadata (start/end dates, dataset, covariates).
+- **Session-aware navigation**: Saved experiments persist during the browser session and can be revisited from the sidebar dropdown.
+- **Stylized dashboard**: Each mock experiment produces the same sample dashboard to demonstrate the future presentation layer for causal analysis results.
+
+## Getting Started
+
+### 1. Create the Conda environment
+
+```bash
+conda env create -f env.yml
+conda activate experimentation_app
+```
+
+The environment installs Python 3.12, CausalPy, and supporting Dash/Plotly packages required to run the mock interface locally.
+
+### 2. Launch the Dash application
+
+```bash
+python app.py
+```
+
+The development server defaults to `http://127.0.0.1:8050/`.
+
+## Using the Interface
+
+1. **Draft a request**: Enter an experiment description in the message area.
+2. **Add structured inputs**: Click the `+` icon to toggle fields for start/end date, dataset, and covariates.
+3. **Run the mock experiment**: Press **Run mock experiment** to save the request. A prebuilt dashboard appears with illustrative charts and insights.
+4. **Switch between experiments**: Use the sidebar dropdown to jump back to previous mock experiments created during the current session.
+5. **Start fresh**: Select **New Experiment** in the top bar to clear the form and prepare a new request while keeping saved experiments available in the sidebar.
+
+## Next Steps
+
+This scaffold can be extended by integrating real data ingestion, invoking CausalPy estimators, and persisting experiments to a database or API. The current version focuses on the look-and-feel of the eventual experimentation studio.

--- a/Experimentation/site/app.py
+++ b/Experimentation/site/app.py
@@ -225,15 +225,25 @@ app.layout = html.Div(
                                                 html.Div(
                                                     className="attachment-field",
                                                     children=[
-                                                        html.Span("Start date", className="field-label"),
-                                                        dcc.Input(id="start-date", type="date", className="field-input"),
+                                                html.Span("Start date", className="field-label"),
+                                                dcc.DatePickerSingle(
+                                                    id="start-date",
+                                                    className="field-input date-input",
+                                                    display_format="YYYY-MM-DD",
+                                                    placeholder="YYYY-MM-DD",
+                                                ),
                                                     ],
                                                 ),
                                                 html.Div(
                                                     className="attachment-field",
                                                     children=[
                                                         html.Span("End date", className="field-label"),
-                                                        dcc.Input(id="end-date", type="date", className="field-input"),
+                                                dcc.DatePickerSingle(
+                                                    id="end-date",
+                                                    className="field-input date-input",
+                                                    display_format="YYYY-MM-DD",
+                                                    placeholder="YYYY-MM-DD",
+                                                ),
                                                     ],
                                                 ),
                                                 html.Div(
@@ -333,15 +343,15 @@ def refresh_experiment_list(store_data: Dict[str, Any]):
     Output("experiments-store", "data"),
     Output("experiment-selector", "value"),
     Output("message-input", "value"),
-    Output("start-date", "value"),
-    Output("end-date", "value"),
+    Output("start-date", "date"),
+    Output("end-date", "date"),
     Output("dataset-input", "value"),
     Output("covariates-input", "value"),
     Input("run-experiment-button", "n_clicks"),
     Input("new-experiment-button", "n_clicks"),
     State("message-input", "value"),
-    State("start-date", "value"),
-    State("end-date", "value"),
+    State("start-date", "date"),
+    State("end-date", "date"),
     State("dataset-input", "value"),
     State("covariates-input", "value"),
     State("experiments-store", "data"),
@@ -384,7 +394,7 @@ def handle_experiment_actions(
             "end_date": end_date or "2025-04-15",
             "dataset": dataset or "Germany Retail",
             "covariates": covariates or "Seasonality, Spend",
-            "created_at": datetime.datetime.utcnow().isoformat(),
+            "created_at": datetime.datetime.now(datetime.UTC).isoformat(),
         }
         experiments.append(experiment)
         store_data = {"experiments": experiments, "counter": counter, "selected_id": experiment_id}
@@ -423,4 +433,4 @@ def render_dashboard(selected_id: Optional[str], store_data: Dict[str, Any]):
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    app.run(debug=True)

--- a/Experimentation/site/app.py
+++ b/Experimentation/site/app.py
@@ -27,7 +27,7 @@ DEFAULT_LIFT_SUMMARY = pd.DataFrame(
 
 def _make_experiment_name(counter: int, message: Optional[str]) -> str:
     if message:
-        preview = " ".join(message.split())[:24]
+        preview = " ".join(message.split())[:24].rstrip()
         if preview:
             return f"Experiment {counter}: {preview}"
     return f"Experiment {counter}"

--- a/Experimentation/site/app.py
+++ b/Experimentation/site/app.py
@@ -1,0 +1,426 @@
+import datetime
+import uuid
+from typing import Any, Dict, List, Optional
+
+import dash
+from dash import Dash, Input, Output, State, callback_context, dcc, html
+import dash_bootstrap_components as dbc
+import pandas as pd
+import plotly.express as px
+
+
+APP_TITLE = "Experimentation Studio"
+DEFAULT_DASHBOARD_DATA = pd.DataFrame(
+    {
+        "Date": pd.date_range("2025-03-15", periods=14, freq="D"),
+        "Control": [120, 118, 122, 125, 130, 128, 132, 135, 138, 140, 142, 144, 146, 148],
+        "Treatment": [119, 120, 126, 131, 137, 139, 141, 145, 150, 153, 155, 158, 160, 164],
+    }
+)
+DEFAULT_LIFT_SUMMARY = pd.DataFrame(
+    {
+        "Metric": ["Average Uplift", "Peak Uplift", "Post-Period Uplift"],
+        "Value": [5.4, 12.8, 8.9],
+    }
+)
+
+
+def _make_experiment_name(counter: int, message: Optional[str]) -> str:
+    if message:
+        preview = " ".join(message.split())[:24]
+        if preview:
+            return f"Experiment {counter}: {preview}"
+    return f"Experiment {counter}"
+
+
+def create_dashboard_components(experiment: Dict[str, Any]) -> html.Div:
+    fig = px.line(
+        DEFAULT_DASHBOARD_DATA,
+        x="Date",
+        y=["Control", "Treatment"],
+        labels={"value": "Metric", "variable": "Group"},
+        template="plotly_dark",
+    )
+    fig.update_layout(
+        margin=dict(l=0, r=0, t=32, b=0),
+        paper_bgcolor="rgba(12,14,30,0.8)",
+        plot_bgcolor="rgba(12,14,30,0.5)",
+        legend=dict(orientation="h", y=1.1, x=0.5, xanchor="center"),
+        title=dict(
+            text="Estimated Effect Over Time",
+            font=dict(color="#B8B4FF", size=20),
+            x=0.5,
+        ),
+    )
+
+    lift_fig = px.bar(
+        DEFAULT_LIFT_SUMMARY,
+        x="Metric",
+        y="Value",
+        labels={"Value": "Lift (%)"},
+        template="plotly_dark",
+        color="Metric",
+        color_discrete_sequence=["#7F5AF0", "#2CB1FF", "#00B4D8"],
+    )
+    lift_fig.update_layout(
+        margin=dict(l=0, r=0, t=32, b=0),
+        paper_bgcolor="rgba(12,14,30,0.8)",
+        plot_bgcolor="rgba(12,14,30,0.5)",
+        title=dict(
+            text="Lift Summary",
+            font=dict(color="#B8B4FF", size=20),
+            x=0.5,
+        ),
+        xaxis=dict(color="#E0E7FF"),
+        yaxis=dict(color="#E0E7FF"),
+    )
+
+    info_cards = html.Div(
+        className="dashboard-cards",
+        children=[
+            html.Div(
+                className="dashboard-card",
+                children=[
+                    html.Div("Primary Metric", className="card-label"),
+                    html.Div("Conversion Rate", className="card-value"),
+                ],
+            ),
+            html.Div(
+                className="dashboard-card",
+                children=[
+                    html.Div("Start → End", className="card-label"),
+                    html.Div(
+                        f"{experiment.get('start_date', 'Apr 01, 2025')} → {experiment.get('end_date', 'Apr 15, 2025')}",
+                        className="card-value",
+                    ),
+                ],
+            ),
+            html.Div(
+                className="dashboard-card",
+                children=[
+                    html.Div("Region", className="card-label"),
+                    html.Div(experiment.get("dataset", "Germany Retail"), className="card-value"),
+                ],
+            ),
+            html.Div(
+                className="dashboard-card",
+                children=[
+                    html.Div("Status", className="card-label"),
+                    html.Div("Completed", className="card-value status"),
+                ],
+            ),
+        ],
+    )
+
+    figure_row = html.Div(
+        className="figure-row",
+        children=[
+            html.Div(className="figure-card", children=[dcc.Graph(figure=fig, config={"displayModeBar": False})]),
+            html.Div(className="figure-card", children=[dcc.Graph(figure=lift_fig, config={"displayModeBar": False})]),
+        ],
+    )
+
+    notes = html.Div(
+        className="insights-panel",
+        children=[
+            html.H3("Insights", className="panel-title"),
+            html.Ul(
+                children=[
+                    html.Li("Treatment outperforms control by ~8% post intervention."),
+                    html.Li("No significant pre-period imbalance detected."),
+                    html.Li("Covariates remain stable; uplift is likely attributable to the experiment."),
+                ]
+            ),
+        ],
+    )
+
+    experiment_brief = html.Div(
+        className="experiment-brief",
+        children=[
+            html.H3("Experiment Summary", className="panel-title"),
+            html.Div(
+                className="brief-item",
+                children=[
+                    html.Span("Prompt", className="brief-label"),
+                    html.P(experiment.get("message", "Not provided")),
+                ],
+            ),
+            html.Div(
+                className="brief-item",
+                children=[
+                    html.Span("Covariates", className="brief-label"),
+                    html.P(experiment.get("covariates", "Seasonality, Spend")),
+                ],
+            ),
+        ],
+    )
+
+    return html.Div(
+        className="dashboard-wrapper",
+        children=[info_cards, figure_row, html.Div(className="panel-grid", children=[notes, experiment_brief])],
+    )
+
+
+app: Dash = dash.Dash(__name__, external_stylesheets=[dbc.icons.BOOTSTRAP])
+app.title = APP_TITLE
+
+app.layout = html.Div(
+    className="app-shell",
+    children=[
+        dcc.Store(id="experiments-store", data={"experiments": [], "counter": 0, "selected_id": None}),
+        dcc.Store(id="attachments-store", data={"open": False}),
+        html.Div(
+            className="top-bar",
+            children=[
+                html.Div(APP_TITLE, className="app-title"),
+                html.Button("New Experiment", id="new-experiment-button", className="primary-button"),
+            ],
+        ),
+        html.Div(
+            className="workspace",
+            children=[
+                html.Div(
+                    className="sidebar",
+                    children=[
+                        html.Div("Your Experiments", className="sidebar-title"),
+                        dcc.Dropdown(
+                            id="experiment-selector",
+                            placeholder="Jump to an experiment",
+                            className="experiment-dropdown",
+                            clearable=False,
+                        ),
+                        html.Div(id="experiment-list", className="experiment-list"),
+                    ],
+                ),
+                html.Div(
+                    className="main-content",
+                    children=[
+                        html.Div(
+                            className="prompt-card",
+                            children=[
+                                html.Div("What are you researching?", className="prompt-title"),
+                                html.Div(
+                                    className="message-box",
+                                    children=[
+                                        dcc.Textarea(
+                                            id="message-input",
+                                            placeholder=(
+                                                "Run an experiment from April 1, 2025 to April 15, 2025, in Germany.\n"
+                                                "Here is a dataset with my metric in Germany—check if the experiment was successful."
+                                            ),
+                                            className="message-textarea",
+                                            value="",
+                                        ),
+                                        html.Div(
+                                            className="attachment-controls",
+                                            children=[
+                                                html.Button("+", id="attachment-toggle", className="attachment-button"),
+                                                html.Span("Add details", className="attachment-label"),
+                                            ],
+                                        ),
+                                        html.Div(
+                                            id="attachment-panel",
+                                            className="attachment-panel hidden",
+                                            children=[
+                                                html.Div(
+                                                    className="attachment-field",
+                                                    children=[
+                                                        html.Span("Start date", className="field-label"),
+                                                        dcc.Input(id="start-date", type="date", className="field-input"),
+                                                    ],
+                                                ),
+                                                html.Div(
+                                                    className="attachment-field",
+                                                    children=[
+                                                        html.Span("End date", className="field-label"),
+                                                        dcc.Input(id="end-date", type="date", className="field-input"),
+                                                    ],
+                                                ),
+                                                html.Div(
+                                                    className="attachment-field",
+                                                    children=[
+                                                        html.Span("Dataset", className="field-label"),
+                                                        dcc.Input(
+                                                            id="dataset-input",
+                                                            type="text",
+                                                            placeholder="Upload path or table name",
+                                                            className="field-input",
+                                                        ),
+                                                    ],
+                                                ),
+                                                html.Div(
+                                                    className="attachment-field",
+                                                    children=[
+                                                        html.Span("Covariates", className="field-label"),
+                                                        dcc.Input(
+                                                            id="covariates-input",
+                                                            type="text",
+                                                            placeholder="Seasonality, Spend, CPC",
+                                                            className="field-input",
+                                                        ),
+                                                    ],
+                                                ),
+                                            ],
+                                        ),
+                                    ],
+                                ),
+                                html.Button("Run mock experiment", id="run-experiment-button", className="primary-button"),
+                            ],
+                        ),
+                        html.Div(id="dashboard-container", className="dashboard-container"),
+                    ],
+                ),
+            ],
+        ),
+    ],
+)
+
+
+@app.callback(
+    Output("attachments-store", "data"),
+    Input("attachment-toggle", "n_clicks"),
+    State("attachments-store", "data"),
+    prevent_initial_call=True,
+)
+def toggle_attachments(n_clicks: int, state: Dict[str, Any]) -> Dict[str, Any]:
+    open_state = state.get("open", False)
+    return {"open": not open_state}
+
+
+@app.callback(
+    Output("attachment-panel", "className"),
+    Input("attachments-store", "data"),
+)
+def set_attachment_panel(data: Dict[str, Any]) -> str:
+    base_class = "attachment-panel"
+    if not data.get("open"):
+        return f"{base_class} hidden"
+    return base_class
+
+
+@app.callback(
+    Output("experiment-selector", "options"),
+    Output("experiment-list", "children"),
+    Input("experiments-store", "data"),
+)
+def refresh_experiment_list(store_data: Dict[str, Any]):
+    experiments: List[Dict[str, Any]] = store_data.get("experiments", [])
+    options = [
+        {"label": exp["name"], "value": exp["id"]}
+        for exp in experiments
+    ]
+
+    cards = []
+    for exp in experiments:
+        cards.append(
+            html.Div(
+                className="sidebar-experiment",
+                children=[
+                    html.Div(exp["name"], className="sidebar-experiment-name"),
+                    html.Div(
+                        f"{exp.get('start_date', 'Start?')} → {exp.get('end_date', 'End?')}",
+                        className="sidebar-experiment-meta",
+                    ),
+                ],
+            )
+        )
+
+    empty_state = html.Div("No experiments yet. Run one to get started!", className="sidebar-empty")
+    return options, cards if cards else empty_state
+
+
+@app.callback(
+    Output("experiments-store", "data"),
+    Output("experiment-selector", "value"),
+    Output("message-input", "value"),
+    Output("start-date", "value"),
+    Output("end-date", "value"),
+    Output("dataset-input", "value"),
+    Output("covariates-input", "value"),
+    Input("run-experiment-button", "n_clicks"),
+    Input("new-experiment-button", "n_clicks"),
+    State("message-input", "value"),
+    State("start-date", "value"),
+    State("end-date", "value"),
+    State("dataset-input", "value"),
+    State("covariates-input", "value"),
+    State("experiments-store", "data"),
+    prevent_initial_call=True,
+)
+def handle_experiment_actions(
+    run_clicks: Optional[int],
+    new_clicks: Optional[int],
+    message: Optional[str],
+    start_date: Optional[str],
+    end_date: Optional[str],
+    dataset: Optional[str],
+    covariates: Optional[str],
+    store_data: Dict[str, Any],
+):
+    triggered = callback_context.triggered_id
+    experiments = store_data.get("experiments", [])
+    counter = store_data.get("counter", 0)
+
+    if triggered == "run-experiment-button":
+        if not message and not any([start_date, end_date, dataset, covariates]):
+            return (
+                store_data,
+                store_data.get("selected_id"),
+                message,
+                start_date,
+                end_date,
+                dataset,
+                covariates,
+            )
+
+        counter += 1
+        experiment_id = str(uuid.uuid4())
+        name = _make_experiment_name(counter, message)
+        experiment = {
+            "id": experiment_id,
+            "name": name,
+            "message": message or "",
+            "start_date": start_date or "2025-04-01",
+            "end_date": end_date or "2025-04-15",
+            "dataset": dataset or "Germany Retail",
+            "covariates": covariates or "Seasonality, Spend",
+            "created_at": datetime.datetime.utcnow().isoformat(),
+        }
+        experiments.append(experiment)
+        store_data = {"experiments": experiments, "counter": counter, "selected_id": experiment_id}
+        return store_data, experiment_id, "", None, None, "", ""
+
+    if triggered == "new-experiment-button":
+        store_data["selected_id"] = None
+        return store_data, None, "", None, None, "", ""
+
+    return store_data, store_data.get("selected_id"), message, start_date, end_date, dataset, covariates
+
+
+@app.callback(
+    Output("dashboard-container", "children"),
+    Input("experiment-selector", "value"),
+    Input("experiments-store", "data"),
+)
+def render_dashboard(selected_id: Optional[str], store_data: Dict[str, Any]):
+    experiments = store_data.get("experiments", [])
+    experiment_lookup = {exp["id"]: exp for exp in experiments}
+
+    if selected_id and selected_id in experiment_lookup:
+        experiment = experiment_lookup[selected_id]
+        return create_dashboard_components(experiment)
+
+    return html.Div(
+        className="dashboard-empty",
+        children=[
+            html.H2("Ready when you are", className="empty-title"),
+            html.P(
+                "Draft a prompt or add structured inputs, then run a mock experiment to see insights here.",
+                className="empty-description",
+            ),
+        ],
+    )
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/Experimentation/site/assets/style.css
+++ b/Experimentation/site/assets/style.css
@@ -1,0 +1,390 @@
+:root {
+  --bg-gradient: linear-gradient(135deg, rgba(15, 16, 37, 0.9), rgba(20, 24, 55, 0.95));
+  --card-bg: rgba(24, 26, 60, 0.85);
+  --accent-purple: #7f5af0;
+  --accent-blue: #2cb1ff;
+  --accent-cyan: #00b4d8;
+  --text-primary: #f5f7ff;
+  --text-secondary: #c5c8ff;
+  --border-radius: 18px;
+  --border-color: rgba(127, 90, 240, 0.35);
+  --shadow: 0 18px 35px rgba(8, 10, 24, 0.45);
+  --sidebar-width: 320px;
+  --font-family: "Inter", "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top left, rgba(127, 90, 240, 0.25), transparent 40%),
+    radial-gradient(circle at bottom right, rgba(44, 177, 255, 0.2), transparent 35%),
+    var(--bg-gradient);
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 36px;
+  backdrop-filter: blur(14px);
+  background: rgba(8, 10, 28, 0.55);
+  border-bottom: 1px solid rgba(127, 90, 240, 0.3);
+}
+
+.app-title {
+  font-size: 1.4rem;
+  letter-spacing: 0.08rem;
+  text-transform: uppercase;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, var(--accent-purple), var(--accent-blue));
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 22px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 10px 25px rgba(44, 177, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.3s ease;
+}
+
+.primary-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 14px 30px rgba(127, 90, 240, 0.45);
+}
+
+.workspace {
+  display: flex;
+  flex: 1;
+  padding: 24px 32px;
+  gap: 28px;
+}
+
+.sidebar {
+  width: var(--sidebar-width);
+  background: rgba(16, 18, 44, 0.8);
+  border-radius: var(--border-radius);
+  border: 1px solid var(--border-color);
+  padding: 24px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sidebar-title {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.experiment-dropdown .Select-control,
+.experiment-dropdown .Select-value-label,
+.experiment-dropdown .Select-placeholder {
+  background-color: transparent !important;
+  color: var(--text-primary) !important;
+}
+
+.experiment-dropdown .Select-menu-outer {
+  background-color: rgba(18, 20, 48, 0.95);
+  border: 1px solid rgba(127, 90, 240, 0.4);
+  border-radius: 14px;
+}
+
+.experiment-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar-experiment {
+  background: rgba(24, 26, 64, 0.75);
+  border-radius: 16px;
+  padding: 12px 16px;
+  border: 1px solid rgba(127, 90, 240, 0.3);
+  transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.sidebar-experiment:hover {
+  border-color: rgba(44, 177, 255, 0.5);
+  transform: translateX(3px);
+}
+
+.sidebar-experiment-name {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.sidebar-experiment-meta {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+.sidebar-empty {
+  color: rgba(200, 204, 255, 0.6);
+  font-size: 0.9rem;
+  padding: 12px 0;
+}
+
+.main-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.prompt-card {
+  background: var(--card-bg);
+  border-radius: var(--border-radius);
+  padding: 24px 28px;
+  border: 1px solid rgba(44, 177, 255, 0.25);
+  box-shadow: var(--shadow);
+}
+
+.prompt-title {
+  font-size: 1.3rem;
+  margin-bottom: 16px;
+  color: var(--text-primary);
+}
+
+.message-box {
+  position: relative;
+  background: rgba(12, 14, 36, 0.65);
+  border-radius: 20px;
+  border: 1px solid rgba(127, 90, 240, 0.35);
+  padding: 18px 18px 22px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.message-textarea {
+  background: transparent;
+  color: var(--text-primary);
+  border: none;
+  resize: none;
+  min-height: 140px;
+  font-size: 0.98rem;
+  line-height: 1.5;
+}
+
+.message-textarea:focus {
+  outline: none;
+}
+
+.attachment-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.attachment-button {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid rgba(127, 90, 240, 0.4);
+  background: rgba(127, 90, 240, 0.25);
+  color: var(--text-primary);
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.attachment-button:hover {
+  transform: scale(1.05);
+}
+
+.attachment-label {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.attachment-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 14px;
+  background: rgba(20, 22, 52, 0.9);
+  border: 1px solid rgba(44, 177, 255, 0.35);
+  border-radius: 16px;
+  padding: 16px;
+}
+
+.attachment-panel.hidden {
+  display: none;
+}
+
+.attachment-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.field-input {
+  border-radius: 12px;
+  border: 1px solid rgba(127, 90, 240, 0.35);
+  padding: 10px 12px;
+  background: rgba(10, 12, 32, 0.8);
+  color: var(--text-primary);
+}
+
+.field-input:focus {
+  outline: none;
+  border-color: rgba(44, 177, 255, 0.6);
+}
+
+.dashboard-container {
+  background: rgba(12, 14, 34, 0.65);
+  border-radius: var(--border-radius);
+  padding: 28px;
+  border: 1px solid rgba(127, 90, 240, 0.25);
+  min-height: 320px;
+  box-shadow: var(--shadow);
+}
+
+.dashboard-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--text-secondary);
+}
+
+.empty-title {
+  font-size: 1.6rem;
+  color: var(--text-primary);
+  margin-bottom: 12px;
+}
+
+.empty-description {
+  font-size: 1rem;
+  color: var(--text-secondary);
+}
+
+.dashboard-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.dashboard-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+}
+
+.dashboard-card {
+  background: rgba(25, 27, 62, 0.9);
+  border-radius: 18px;
+  border: 1px solid rgba(127, 90, 240, 0.35);
+  padding: 16px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.card-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.card-value {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.card-value.status {
+  color: var(--accent-blue);
+}
+
+.figure-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.figure-card {
+  background: rgba(25, 27, 58, 0.9);
+  border-radius: 20px;
+  border: 1px solid rgba(44, 177, 255, 0.3);
+  padding: 16px;
+  box-shadow: var(--shadow);
+}
+
+.panel-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.insights-panel,
+.experiment-brief {
+  background: rgba(22, 24, 56, 0.85);
+  border-radius: 18px;
+  border: 1px solid rgba(127, 90, 240, 0.3);
+  padding: 18px 20px;
+  color: var(--text-primary);
+}
+
+.panel-title {
+  margin-top: 0;
+  margin-bottom: 12px;
+  font-size: 1.15rem;
+  color: var(--accent-blue);
+}
+
+.insights-panel ul {
+  padding-left: 20px;
+  margin: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.brief-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 12px;
+}
+
+.brief-label {
+  font-size: 0.82rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.brief-item p {
+  margin: 0;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+@media (max-width: 1100px) {
+  .workspace {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-direction: column;
+  }
+}

--- a/Experimentation/site/env.yml
+++ b/Experimentation/site/env.yml
@@ -12,3 +12,4 @@ dependencies:
       - pandas
       - numpy
       - plotly
+      - pytest

--- a/Experimentation/site/env.yml
+++ b/Experimentation/site/env.yml
@@ -1,0 +1,14 @@
+name: experimentation_app
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python=3.12
+  - causalpy
+  - pip
+  - pip:
+      - dash
+      - dash-bootstrap-components
+      - pandas
+      - numpy
+      - plotly

--- a/Experimentation/site/tests/test_app.py
+++ b/Experimentation/site/tests/test_app.py
@@ -2,7 +2,7 @@
 
 from dash import dcc, html
 
-from Experimentation.site.app import (
+from site.app import (
     _make_experiment_name,
     app,
     create_dashboard_components,

--- a/Experimentation/site/tests/test_app.py
+++ b/Experimentation/site/tests/test_app.py
@@ -1,0 +1,68 @@
+"""Smoke tests for the mock experimentation Dash app."""
+
+from dash import dcc, html
+
+from Experimentation.site.app import (
+    _make_experiment_name,
+    app,
+    create_dashboard_components,
+)
+
+
+def test_make_experiment_name_truncates_and_formats():
+    """The preview suffix should be trimmed to 24 characters with collapsed whitespace."""
+
+    message = "   Multi   spaced   message to ensure trimming works properly  "
+    result = _make_experiment_name(5, message)
+
+    assert result == "Experiment 5: Multi spaced message to"
+
+
+def test_make_experiment_name_defaults_without_message():
+    """If no previewable text is provided the counter alone should be used."""
+
+    assert _make_experiment_name(2, "") == "Experiment 2"
+    assert _make_experiment_name(3, None) == "Experiment 3"
+
+
+def test_create_dashboard_components_structure():
+    """The dashboard wrapper should include key sections and echo back experiment details."""
+
+    experiment = {
+        "message": "Test prompt",
+        "start_date": "2025-04-01",
+        "end_date": "2025-04-15",
+        "dataset": "EU Retail",
+        "covariates": "Seasonality",
+    }
+
+    dashboard = create_dashboard_components(experiment)
+
+    assert isinstance(dashboard, html.Div)
+    assert dashboard.className == "dashboard-wrapper"
+
+    child_classes = [getattr(child, "className", "") for child in dashboard.children]
+    assert "figure-row" in child_classes
+    assert "panel-grid" in child_classes
+
+    panel_grid = next(child for child in dashboard.children if getattr(child, "className", "") == "panel-grid")
+    experiment_summary = next(
+        child for child in panel_grid.children if getattr(child, "className", "") == "experiment-brief"
+    )
+
+    prompt_section = experiment_summary.children[1]
+    prompt_value = prompt_section.children[1].children
+    assert prompt_value == "Test prompt"
+
+
+def test_app_layout_and_callbacks_registered():
+    """Validate the top-level layout wiring and callback registry."""
+
+    layout = app.layout
+    assert isinstance(layout, html.Div)
+
+    stores = [child for child in layout.children if isinstance(child, dcc.Store)]
+    store_ids = {store.id for store in stores}
+    assert store_ids == {"experiments-store", "attachments-store"}
+
+    assert len(app.callback_map) == 5

--- a/Experimentation/site/tests/test_app.py
+++ b/Experimentation/site/tests/test_app.py
@@ -1,75 +1,222 @@
-"""Smoke tests for the mock experimentation Dash app."""
+"""Unit tests for the experimentation Dash app internals."""
 
 import os
 import sys
+from types import SimpleNamespace
+
+import pytest
+from dash import dcc, html
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
-from dash import dcc, html
-
+from Experimentation.site import app as app_module
 from Experimentation.site.app import (
     _make_experiment_name,
     app,
     create_dashboard_components,
+    handle_experiment_actions,
+    refresh_experiment_list,
+    render_dashboard,
+    set_attachment_panel,
+    toggle_attachments,
 )
 
 
-def test_make_experiment_name_truncates_and_formats():
-    """The preview suffix should be trimmed to 24 characters with collapsed whitespace."""
-
-    message = "   Multi   spaced   message to ensure trimming works properly  "
-    result = _make_experiment_name(5, message)
-
-    assert result == "Experiment 5: Multi spaced message to"
-
-
-def test_make_experiment_name_defaults_without_message():
-    """If no previewable text is provided the counter alone should be used."""
-
-    assert _make_experiment_name(2, "") == "Experiment 2"
-    assert _make_experiment_name(3, None) == "Experiment 3"
-
-
-def test_create_dashboard_components_structure():
-    """The dashboard wrapper should include key sections and echo back experiment details."""
-
-    experiment = {
-        "message": "Test prompt",
+@pytest.fixture
+def experiment_payload():
+    return {
+        "message": "Measure conversion lift",
         "start_date": "2025-04-01",
         "end_date": "2025-04-15",
         "dataset": "EU Retail",
-        "covariates": "Seasonality",
+        "covariates": "Seasonality, Spend",
     }
 
-    dashboard = create_dashboard_components(experiment)
+
+@pytest.fixture
+def fresh_store():
+    return {"experiments": [], "counter": 0, "selected_id": None}
+
+
+@pytest.mark.parametrize(
+    ("counter", "message", "expected"),
+    [
+        (5, "   Multi   spaced   message to ensure trimming works properly  ", "Experiment 5: Multi spaced message to"),
+        (2, "", "Experiment 2"),
+        (3, None, "Experiment 3"),
+    ],
+)
+def test_make_experiment_name_formats(counter, message, expected):
+    assert _make_experiment_name(counter, message) == expected
+
+
+def test_create_dashboard_components_sections(experiment_payload):
+    dashboard = create_dashboard_components(experiment_payload)
 
     assert isinstance(dashboard, html.Div)
     assert dashboard.className == "dashboard-wrapper"
 
-    child_classes = [getattr(child, "className", "") for child in dashboard.children]
-    assert "figure-row" in child_classes
-    assert "panel-grid" in child_classes
+    class_names = {getattr(child, "className", "") for child in dashboard.children}
+    assert {"dashboard-cards", "figure-row", "panel-grid"} <= class_names
+
+    figure_row = next(child for child in dashboard.children if getattr(child, "className", "") == "figure-row")
+    graphs = [
+        grandchild
+        for card in figure_row.children
+        for grandchild in getattr(card, "children", [])
+        if isinstance(grandchild, dcc.Graph)
+    ]
+    assert len(graphs) == 2
 
     panel_grid = next(child for child in dashboard.children if getattr(child, "className", "") == "panel-grid")
-    experiment_summary = next(
-        child for child in panel_grid.children if getattr(child, "className", "") == "experiment-brief"
+    experiment_brief = next(child for child in panel_grid.children if getattr(child, "className", "") == "experiment-brief")
+    prompt_section = experiment_brief.children[1]
+    assert prompt_section.children[1].children == experiment_payload["message"]
+
+
+def test_toggle_attachments_toggles_open_flag():
+    assert toggle_attachments(1, {"open": False}) == {"open": True}
+    assert toggle_attachments(2, {"open": True}) == {"open": False}
+    assert toggle_attachments(3, {}) == {"open": True}
+
+
+def test_set_attachment_panel_respects_open_state():
+    assert set_attachment_panel({"open": True}) == "attachment-panel"
+    assert set_attachment_panel({"open": False}) == "attachment-panel hidden"
+    assert set_attachment_panel({}) == "attachment-panel hidden"
+
+
+def test_refresh_experiment_list_with_experiments():
+    store_data = {
+        "experiments": [
+            {
+                "id": "exp-01",
+                "name": "Experiment 1",
+                "start_date": "2025-04-01",
+                "end_date": "2025-04-15",
+            }
+        ]
+    }
+
+    options, children = refresh_experiment_list(store_data)
+
+    assert options == [{"label": "Experiment 1", "value": "exp-01"}]
+    assert isinstance(children, list)
+    assert children[0].className == "sidebar-experiment"
+
+
+def test_refresh_experiment_list_without_experiments():
+    options, children = refresh_experiment_list({"experiments": []})
+
+    assert options == []
+    assert isinstance(children, html.Div)
+    assert children.className == "sidebar-empty"
+
+
+def test_handle_experiment_actions_creates_new_experiment(monkeypatch, fresh_store, experiment_payload):
+    monkeypatch.setattr(app_module, "callback_context", SimpleNamespace(triggered_id="run-experiment-button"))
+
+    result = handle_experiment_actions(
+        run_clicks=1,
+        new_clicks=None,
+        message=experiment_payload["message"],
+        start_date=experiment_payload["start_date"],
+        end_date=experiment_payload["end_date"],
+        dataset=experiment_payload["dataset"],
+        covariates=experiment_payload["covariates"],
+        store_data=fresh_store,
     )
 
-    prompt_section = experiment_summary.children[1]
-    prompt_value = prompt_section.children[1].children
-    assert prompt_value == "Test prompt"
+    store_after, selected_id, message_value, start_date, end_date, dataset, covariates = result
+
+    assert store_after["counter"] == 1
+    assert len(store_after["experiments"]) == 1
+
+    experiment = store_after["experiments"][0]
+    assert experiment["message"] == experiment_payload["message"]
+    assert experiment["start_date"] == experiment_payload["start_date"]
+    assert experiment["dataset"] == experiment_payload["dataset"]
+    assert experiment["covariates"] == experiment_payload["covariates"]
+    assert isinstance(experiment["id"], str)
+    assert isinstance(experiment["created_at"], str)
+
+    assert selected_id == experiment["id"]
+    assert message_value == ""
+    assert start_date is None
+    assert end_date is None
+    assert dataset == ""
+    assert covariates == ""
 
 
-def test_app_layout_and_callbacks_registered():
-    """Validate the top-level layout wiring and callback registry."""
+def test_handle_experiment_actions_ignores_empty_submission(monkeypatch, fresh_store):
+    monkeypatch.setattr(app_module, "callback_context", SimpleNamespace(triggered_id="run-experiment-button"))
 
+    result = handle_experiment_actions(
+        run_clicks=1,
+        new_clicks=None,
+        message="",
+        start_date=None,
+        end_date=None,
+        dataset="",
+        covariates="",
+        store_data=fresh_store,
+    )
+
+    assert result[0] is fresh_store
+    assert result[1] == fresh_store["selected_id"]
+
+
+def test_handle_experiment_actions_new_button_resets_form(monkeypatch):
+    store_data = {"experiments": [], "counter": 2, "selected_id": "exp-02"}
+    monkeypatch.setattr(app_module, "callback_context", SimpleNamespace(triggered_id="new-experiment-button"))
+
+    result = handle_experiment_actions(
+        run_clicks=None,
+        new_clicks=1,
+        message="Keep existing",
+        start_date="2025-04-01",
+        end_date="2025-04-15",
+        dataset="EU Retail",
+        covariates="Seasonality",
+        store_data=store_data,
+    )
+
+    returned_store, selector_value, message_value, start_date, end_date, dataset, covariates = result
+
+    assert returned_store["selected_id"] is None
+    assert selector_value is None
+    assert message_value == ""
+    assert start_date is None
+    assert end_date is None
+    assert dataset == ""
+    assert covariates == ""
+
+
+def test_render_dashboard_empty_state(fresh_store):
+    component = render_dashboard(selected_id=None, store_data=fresh_store)
+
+    assert isinstance(component, html.Div)
+    assert component.className == "dashboard-empty"
+
+
+def test_render_dashboard_selected_experiment(monkeypatch):
+    experiment = {"id": "exp-01"}
+    store_data = {"experiments": [experiment]}
+    sentinel = html.Div(id="sentinel-dashboard")
+
+    monkeypatch.setattr(app_module, "create_dashboard_components", lambda exp: sentinel)
+
+    component = render_dashboard(selected_id="exp-01", store_data=store_data)
+
+    assert component is sentinel
+
+
+def test_app_layout_contains_expected_sections():
     layout = app.layout
+
     assert isinstance(layout, html.Div)
-
-    stores = [child for child in layout.children if isinstance(child, dcc.Store)]
-    store_ids = {store.id for store in stores}
+    store_ids = {child.id for child in layout.children if isinstance(child, dcc.Store)}
     assert store_ids == {"experiments-store", "attachments-store"}
-
-    assert len(app.callback_map) == 5
+    assert app.title == "Experimentation Studio"

--- a/Experimentation/site/tests/test_app.py
+++ b/Experimentation/site/tests/test_app.py
@@ -1,8 +1,15 @@
 """Smoke tests for the mock experimentation Dash app."""
 
+import os
+import sys
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
+
 from dash import dcc, html
 
-from site.app import (
+from Experimentation.site.app import (
     _make_experiment_name,
     app,
     create_dashboard_components,


### PR DESCRIPTION
## Summary
- build a Dash-based mock experimentation workspace with prompt input, attachments, and saved sessions
- add Plotly dashboards and styling to visualize a static experiment outcome
- document local setup steps and update the environment specification for required dependencies

## Testing
- not run (environment missing runtime dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68e0dbe75b1c8323b7be7807d8214579